### PR TITLE
chore: update AWS CLI installation instructions

### DIFF
--- a/steps-to-setup-azure-agent-ubuntu/README.md
+++ b/steps-to-setup-azure-agent-ubuntu/README.md
@@ -103,7 +103,7 @@ Finally, follow the [official guide](https://learn.microsoft.com/en-us/azure/dev
 Install
 
 ```sh
-snap install aws-cli --classic
+sudo snap install aws-cli --classic
 ```
 
 Check

--- a/steps-to-setup-azure-agent-ubuntu/README.md
+++ b/steps-to-setup-azure-agent-ubuntu/README.md
@@ -103,9 +103,7 @@ Finally, follow the [official guide](https://learn.microsoft.com/en-us/azure/dev
 Install
 
 ```sh
-sudo apt update
-
-sudo apt install awscli
+snap install aws-cli --classic
 ```
 
 Check


### PR DESCRIPTION
- README.md
  - Replace `apt install awscli` with `snap install aws-cli --classic`